### PR TITLE
알람 엔티티 생성, 알림 저장 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 	testImplementation 'org.mockito:mockito-junit-jupiter'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -1,10 +1,13 @@
 package com.gucci.alarm_service.controller;
 
 import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.dto.NotificationRequest;
+import com.gucci.alarm_service.dto.NotificationResponse;
 import com.gucci.alarm_service.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,8 +18,8 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @PostMapping("/send")
-    public ResponseEntity<Void> alarmCreate(Notification notification) {
-        notificationService.save(notification);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<NotificationResponse> alarmCreate(@RequestBody NotificationRequest notificationRequest) {
+        NotificationResponse save = notificationService.save(notificationRequest);
+        return ResponseEntity.ok().body(save);
     }
 }

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -1,0 +1,22 @@
+package com.gucci.alarm_service.controller;
+
+import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @PostMapping("/send")
+    public ResponseEntity<Void> alarmCreate(Notification notification) {
+        notificationService.save(notification);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gucci/alarm_service/domain/Notification.java
+++ b/src/main/java/com/gucci/alarm_service/domain/Notification.java
@@ -1,0 +1,38 @@
+package com.gucci.alarm_service.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long receiverId;
+
+    private Long senderId; // 시스템 알림일 시 null
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private String content;
+
+    private String targetUrl;
+
+    private Long referenceId;
+
+    private boolean isRead = false;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/gucci/alarm_service/domain/Notification.java
+++ b/src/main/java/com/gucci/alarm_service/domain/Notification.java
@@ -32,7 +32,14 @@ public class Notification {
 
     private Long referenceId;
 
-    private boolean isRead = false;
+    private boolean isRead; // 기본값 false
 
-    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist(){
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/gucci/alarm_service/domain/NotificationType.java
+++ b/src/main/java/com/gucci/alarm_service/domain/NotificationType.java
@@ -1,0 +1,9 @@
+package com.gucci.alarm_service.domain;
+
+public enum NotificationType {
+    FOLLOW,     // 누군가 나를 팔로우 했을 때
+    COMMENT,    // 내가 쓴 글에 댓글이 달렸을 때
+    POST,       // 팔로잉 한 사람이 새 글을 썼을 때
+    DM,         // 쪽지가 왔을 때
+    SYSTEM      // 시스템 공지, 이벤트 안내 등
+}

--- a/src/main/java/com/gucci/alarm_service/dto/NotificationRequest.java
+++ b/src/main/java/com/gucci/alarm_service/dto/NotificationRequest.java
@@ -1,0 +1,4 @@
+package com.gucci.alarm_service.dto;
+
+public class NotificationRequest {
+}

--- a/src/main/java/com/gucci/alarm_service/dto/NotificationRequest.java
+++ b/src/main/java/com/gucci/alarm_service/dto/NotificationRequest.java
@@ -1,4 +1,16 @@
 package com.gucci.alarm_service.dto;
 
+import com.gucci.alarm_service.domain.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class NotificationRequest {
+    private Long receiverId;
+    private Long senderId;
+    private NotificationType type;
+    private String content;
+    private String targetUrl;
+    private Long referenceId;
 }

--- a/src/main/java/com/gucci/alarm_service/dto/NotificationResponse.java
+++ b/src/main/java/com/gucci/alarm_service/dto/NotificationResponse.java
@@ -1,4 +1,36 @@
 package com.gucci.alarm_service.dto;
 
+import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.domain.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
 public class NotificationResponse {
+    private Long id;
+    private Long receiverId;
+    private Long senderId;
+    private NotificationType type;
+    private String content;
+    private String targetUrl;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .receiverId(notification.getReceiverId())
+                .senderId(notification.getSenderId())
+                .type(notification.getType())
+                .content(notification.getContent())
+                .targetUrl(notification.getTargetUrl())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+
 }
+

--- a/src/main/java/com/gucci/alarm_service/dto/NotificationResponse.java
+++ b/src/main/java/com/gucci/alarm_service/dto/NotificationResponse.java
@@ -1,0 +1,4 @@
+package com.gucci.alarm_service.dto;
+
+public class NotificationResponse {
+}

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.gucci.alarm_service.repository;
+
+import com.gucci.alarm_service.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/gucci/alarm_service/service/NotificationService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationService.java
@@ -1,6 +1,8 @@
 package com.gucci.alarm_service.service;
 
 import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.dto.NotificationRequest;
+import com.gucci.alarm_service.dto.NotificationResponse;
 import com.gucci.alarm_service.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,7 +12,18 @@ import org.springframework.stereotype.Service;
 public class NotificationService {
     private final NotificationRepository notificationRepository;
 
-    public Notification save(Notification notification){
-        return notificationRepository.save(notification);
+    public NotificationResponse save(NotificationRequest request){
+        Notification notification = Notification.builder()
+                .receiverId(request.getReceiverId())
+                .senderId(request.getSenderId())
+                .type(request.getType())
+                .content(request.getContent())
+                .targetUrl(request.getTargetUrl())
+                .referenceId(request.getReferenceId())
+                .build();
+
+        Notification save = notificationRepository.save(notification);
+
+        return NotificationResponse.from(save);
     }
 }

--- a/src/main/java/com/gucci/alarm_service/service/NotificationService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationService.java
@@ -1,0 +1,16 @@
+package com.gucci.alarm_service.service;
+
+import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    public Notification save(Notification notification){
+        return notificationRepository.save(notification);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,7 @@ spring:
     url: ${LOCAL_DB_URL}
     username: ${LOCAL_DB_USERNAME}
     password: ${LOCAL_DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
+++ b/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
@@ -1,0 +1,45 @@
+package com.gucci.alarm_service.service;
+
+import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.domain.NotificationType;
+import com.gucci.alarm_service.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceTest {
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    void 알림을_정상적으로_저장할_수_있다() {
+        //given
+        Notification notification = Notification.builder()
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.COMMENT)
+                .content("댓글이 달렸습니다.")
+                .targetUrl("/blog/123")
+                .referenceId(123L)
+                .build();
+
+        Mockito.when(notificationRepository.save(notification)).thenReturn(notification);
+
+        //when
+        Notification saved = notificationService.save(notification);
+
+        //then
+        assertThat(saved.getReceiverId()).isEqualTo(1L);
+        assertThat(saved.getType()).isEqualTo(NotificationType.COMMENT);
+        assertThat(saved.getContent()).isEqualTo("댓글이 달렸습니다.");
+    }
+}

--- a/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
+++ b/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
@@ -2,6 +2,8 @@ package com.gucci.alarm_service.service;
 
 import com.gucci.alarm_service.domain.Notification;
 import com.gucci.alarm_service.domain.NotificationType;
+import com.gucci.alarm_service.dto.NotificationRequest;
+import com.gucci.alarm_service.dto.NotificationResponse;
 import com.gucci.alarm_service.repository.NotificationRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +25,7 @@ public class NotificationServiceTest {
     @Test
     void 알림을_정상적으로_저장할_수_있다() {
         //given
-        Notification notification = Notification.builder()
+        NotificationRequest request = NotificationRequest.builder()
                 .receiverId(1L)
                 .senderId(2L)
                 .type(NotificationType.COMMENT)
@@ -32,10 +34,20 @@ public class NotificationServiceTest {
                 .referenceId(123L)
                 .build();
 
-        Mockito.when(notificationRepository.save(notification)).thenReturn(notification);
+        Notification expected = Notification.builder()
+                .receiverId(request.getReceiverId())
+                .senderId(request.getSenderId())
+                .type(request.getType())
+                .content(request.getContent())
+                .targetUrl(request.getTargetUrl())
+                .referenceId(request.getReferenceId())
+                .build();
+
+
+        Mockito.when(notificationRepository.save(Mockito.any(Notification.class))).thenReturn(expected);
 
         //when
-        Notification saved = notificationService.save(notification);
+        NotificationResponse saved = notificationService.save(request);
 
         //then
         assertThat(saved.getReceiverId()).isEqualTo(1L);


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-37](https://sh0314.atlassian.net/browse/GUC-37)
- 관련 GitHub 이슈: #1 

---

## ✨ PR Description

- 알림 서비스의 초기 디렉터리를 구성하고, notification 테이블을 생성하여 알림 정보를 관리하도록 합니다.
- 알림 저장 기능 구현 완료

---

## 📝 Requirements for Reviewer

- 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요
    - ex) 메서드 `handleLoginRedirect()` 명칭 괜찮은지 봐주세요
    - ex) 코드 로직 중 `line 45~56` 성능 개선 가능할지 궁금합니다

---

## ✅ 체크리스트

- [x] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [x] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [x] 불필요한 주석, 디버깅 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-37]: https://sh0314.atlassian.net/browse/GUC-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ