### PR TITLE
알림 조회 / 읽음 처리

### DIFF
--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -5,24 +5,37 @@ import com.gucci.alarm_service.dto.NotificationResponse;
 import com.gucci.alarm_service.service.NotificationService;
 import com.gucci.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/notifications")
+@RequestMapping("/api/alarm-service/notifications")
 public class NotificationController {
     private final NotificationService notificationService;
 
-    @GetMapping( "/subscribe/{userId}")
+    // 알림 연결(구독)
+    @GetMapping("/subscribe/{userId}")
     public SseEmitter subscribe(@PathVariable Long userId) {
         return notificationService.subscribe(userId);
     }
 
+    // 알림 전송
     @PostMapping("/send")
     public ApiResponse<NotificationResponse> alarmCreate(@RequestBody NotificationRequest notificationRequest) {
         NotificationResponse save = notificationService.save(notificationRequest);
         return ApiResponse.success(save);
     }
+
+    // 전체 알림 조회
+    @GetMapping
+    public ApiResponse<List<NotificationResponse>> getAllAlarms(
+            @RequestHeader("X-USER-ID") Long receiverId) { // 로그인된 사용자 ID라고 가정
+        List<NotificationResponse> allAlarams = notificationService.getAllAlarams(receiverId);
+
+        return ApiResponse.success(allAlarams);
+    }
+
 }

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -46,4 +46,12 @@ public class NotificationController {
 
         return ApiResponse.success(unreadAlarms);
     }
+
+    // 알림 읽음 처리
+    @PatchMapping("/{id}/read")
+    public ApiResponse<Void> markRead(@PathVariable Long id) {
+        notificationService.markRead(id);
+
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -38,4 +38,12 @@ public class NotificationController {
         return ApiResponse.success(allAlarams);
     }
 
+    // 안 읽은 알림 조회
+    @GetMapping("/unread")
+    public ApiResponse<List<NotificationResponse>> unreadAlarmList(
+            @RequestHeader("X-USER-ID") Long receiverId) {
+        List<NotificationResponse> unreadAlarms = notificationService.getUnreadAlarms(receiverId);
+
+        return ApiResponse.success(unreadAlarms);
+    }
 }

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -4,6 +4,7 @@ import com.gucci.alarm_service.dto.NotificationRequest;
 import com.gucci.alarm_service.dto.NotificationResponse;
 import com.gucci.alarm_service.service.NotificationService;
 import com.gucci.common.response.ApiResponse;
+import com.gucci.common.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -35,7 +36,7 @@ public class NotificationController {
             @RequestHeader("X-USER-ID") Long receiverId) { // 로그인된 사용자 ID라고 가정
         List<NotificationResponse> allAlarams = notificationService.getAllAlarams(receiverId);
 
-        return ApiResponse.success(allAlarams);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, allAlarams);
     }
 
     // 안 읽은 알림 조회
@@ -44,7 +45,7 @@ public class NotificationController {
             @RequestHeader("X-USER-ID") Long receiverId) {
         List<NotificationResponse> unreadAlarms = notificationService.getUnreadAlarms(receiverId);
 
-        return ApiResponse.success(unreadAlarms);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, unreadAlarms);
     }
 
     // 알림 읽음 처리

--- a/src/main/java/com/gucci/alarm_service/domain/Notification.java
+++ b/src/main/java/com/gucci/alarm_service/domain/Notification.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -41,5 +40,9 @@ public class Notification {
         if (createdAt == null) {
             createdAt = LocalDateTime.now();
         }
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
     }
 }

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -3,6 +3,9 @@ package com.gucci.alarm_service.repository;
 import com.gucci.alarm_service.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
 }

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
+
+    List<Notification> findByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(Long receiverId);
 }

--- a/src/main/java/com/gucci/alarm_service/service/NotificationService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationService.java
@@ -52,4 +52,13 @@ public class NotificationService {
                 .map(NotificationResponse::from)
                 .collect(Collectors.toList());
     }
+
+    // 안 읽은 알림 조회
+    public List<NotificationResponse> getUnreadAlarms(Long receiverId) {
+        List<Notification> unreadAlarams = notificationRepository.findByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(receiverId);
+
+        return unreadAlarams.stream()
+                .map(NotificationResponse::from)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/gucci/alarm_service/service/NotificationService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationService.java
@@ -5,6 +5,9 @@ import com.gucci.alarm_service.domain.Notification;
 import com.gucci.alarm_service.dto.NotificationRequest;
 import com.gucci.alarm_service.dto.NotificationResponse;
 import com.gucci.alarm_service.repository.NotificationRepository;
+import com.gucci.common.exception.CustomException;
+import com.gucci.common.exception.ErrorCode;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -60,5 +63,13 @@ public class NotificationService {
         return unreadAlarams.stream()
                 .map(NotificationResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void markRead(Long id) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_ARGUMENT));
+
+        notification.markAsRead();
     }
 }

--- a/src/main/java/com/gucci/alarm_service/service/NotificationService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationService.java
@@ -9,12 +9,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final SseEmitterManager sseEmitterManager;
 
+    // 알림 저장 및 전송
     public NotificationResponse save(NotificationRequest request){
         Notification notification = Notification.builder()
                 .receiverId(request.getReceiverId())
@@ -35,7 +39,17 @@ public class NotificationService {
         return saved;
     }
 
+    // SSE 연결
     public SseEmitter subscribe(Long userId) {
         return sseEmitterManager.connect(userId);
+    }
+
+    // 전체 알림 조회
+    public List<NotificationResponse> getAllAlarams(Long receiverId) {
+        List<Notification> notifications = notificationRepository.findByReceiverIdOrderByCreatedAtDesc(receiverId);
+
+        return notifications.stream()
+                .map(NotificationResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/gucci/alarm_service/controller/NotificationControllerTest.java
+++ b/src/test/java/com/gucci/alarm_service/controller/NotificationControllerTest.java
@@ -1,0 +1,116 @@
+package com.gucci.alarm_service.controller;
+
+
+import com.gucci.alarm_service.domain.NotificationType;
+import com.gucci.alarm_service.dto.NotificationResponse;
+import com.gucci.alarm_service.service.NotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("알림 읽음 처리 테스트")
+@WebMvcTest(NotificationController.class)
+public class NotificationControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @DisplayName("알림을 읽음 처리 할 수 있다.")
+    @Test
+    void 읽음_처리_성공() throws Exception {
+        // given
+        Long notificationId = 1L;
+
+        // when & then
+        mockMvc.perform(patch("/api/alarm-service/notifications/{id}/read", notificationId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                .andDo(print());
+
+    }
+
+    @DisplayName("전체 알림을 조회할 수 있다.")
+    @Test
+    void 전체_알림_조회_성공() throws Exception {
+        // given
+        Long receiverId = 1L;
+
+        NotificationResponse notice1 = NotificationResponse.builder()
+                .id(1L)
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.COMMENT)
+                .content("새 댓글이 달렸어요")
+                .targetUrl("/posts/1")
+                .isRead(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        NotificationResponse notice2 = NotificationResponse.builder()
+                .id(2L)
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.FOLLOW)
+                .content("누군가 당신을 팔로우했어요")
+                .targetUrl("/follow/2")
+                .isRead(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+
+
+    }
+
+
+    @DisplayName("안 읽은 알림을 조회할 수 있다.")
+    @Test
+    void 안읽은_알림_조회_성공() throws Exception {
+        // given
+        Long receiverId = 1L;
+
+        NotificationResponse unreadNotice = NotificationResponse.builder()
+                .id(1L)
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.COMMENT)
+                .content("새 댓글이 달렸어요")
+                .targetUrl("/posts/1")
+                .isRead(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        List<NotificationResponse> mockUnreadAlarms = List.of(unreadNotice);
+
+        given(notificationService.getUnreadAlarms(receiverId)).willReturn(mockUnreadAlarms);
+
+        // when & then
+        mockMvc.perform(get("/api/alarm-service/notifications/unread")
+                        .header("X-USER-ID", receiverId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("데이터 조회에 성공했습니다."))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(unreadNotice.getId()))
+                .andExpect(jsonPath("$.data[0].read").value(false))
+                .andDo(print());
+
+    }
+
+}

--- a/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
+++ b/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
@@ -5,6 +5,7 @@ import com.gucci.alarm_service.domain.NotificationType;
 import com.gucci.alarm_service.dto.NotificationRequest;
 import com.gucci.alarm_service.dto.NotificationResponse;
 import com.gucci.alarm_service.repository.NotificationRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,7 +13,13 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 public class NotificationServiceTest {
@@ -53,5 +60,68 @@ public class NotificationServiceTest {
         assertThat(saved.getReceiverId()).isEqualTo(1L);
         assertThat(saved.getType()).isEqualTo(NotificationType.COMMENT);
         assertThat(saved.getContent()).isEqualTo("댓글이 달렸습니다.");
+    }
+
+    @DisplayName("안 읽은 알림만 필터링해서 반환")
+    @Test
+    void 안_읽은_알림_반환_성공() {
+        // given
+        Long receiverId = 1L;
+
+        Notification read = Notification.builder()
+                .receiverId(receiverId)
+                .senderId(2L)
+                .type(NotificationType.FOLLOW)
+                .content("읽은 알림")
+                .targetUrl("/url")
+                .isRead(true)
+                .build();
+
+        Notification unread = Notification.builder()
+                .receiverId(receiverId)
+                .senderId(3L)
+                .type(NotificationType.FOLLOW)
+                .content("안 읽은 알림")
+                .targetUrl("/url")
+                .isRead(false)
+                .build();
+
+        given(notificationRepository.findByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(receiverId))
+                .willReturn(List.of(unread));
+
+        // when
+        List<NotificationResponse> result = notificationService.getUnreadAlarms(receiverId);
+
+        //then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).isRead()).isFalse();
+        assertThat(result.get(0).getSenderId()).isEqualTo(3L);
+
+    }
+
+    @DisplayName("알림을 읽음 처리 할 수 있다.")
+    @Test
+    void 알림_읽음_처리_성공() {
+        // given
+        Long notificationId = 1L;
+        Notification notification = Notification.builder()
+                .id(notificationId)
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.COMMENT)
+                .content("댓글이 달렸습니다.")
+                .targetUrl("/posts/1")
+                .isRead(false)
+                .build();
+
+        given(notificationRepository.findById(notificationId)).willReturn(Optional.of(notification));
+
+        // when
+        notificationService.markRead(notificationId);
+
+        // then
+        assertThat(notification.isRead()).isTrue();
+        then(notificationRepository).should().findById(notificationId);
+
     }
 }


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-46](https://sh0314.atlassian.net/browse/GUC-46)
- 관련 GitHub 이슈: #5 

---

## ✨ PR Description

- 전체 알림, 안 읽은 알림을 조회 하는 기능을 추가했습니다.
- 알림을 읽음 처리하는 기능을 추가했습니다. 

---

## 📝 Requirements for Reviewer

---

## ✅ 체크리스트

- [x] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [ ] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [ ] 불필요한 주석, 디버깅 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-46]: https://sh0314.atlassian.net/browse/GUC-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ