### PR TITLE
알림 전체 읽음 처리 / 특정 시간 지난 알림 삭제

### DIFF
--- a/src/main/java/com/gucci/alarm_service/AlarmServiceApplication.java
+++ b/src/main/java/com/gucci/alarm_service/AlarmServiceApplication.java
@@ -2,7 +2,9 @@ package com.gucci.alarm_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class AlarmServiceApplication {
 

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -59,4 +59,12 @@ public class NotificationController {
 
         return ApiResponse.success();
     }
+
+    // 전체 알림 읽음 처리
+    @PatchMapping("/read/all")
+    public ApiResponse<Void> markReadAll(@RequestHeader("X-USER-ID") Long receiverId) {
+        notificationWriteService.markReadAll(receiverId);
+
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -67,4 +67,12 @@ public class NotificationController {
 
         return ApiResponse.success();
     }
+
+    // 전체 알림 삭제
+    @DeleteMapping
+    public ApiResponse<Void> deleteAllAlarms(@RequestHeader("X-USER-ID") Long receiverId) {
+        notificationWriteService.deleteAll(receiverId);
+
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.gucci.alarm_service.repository;
 import com.gucci.alarm_service.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +16,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByReceiverIdAndIsReadFalse(Long receiverId);
 
     void deleteAllByReceiverId(Long receiverId);
+
+    int deleteByIsReadTrueAndCreatedAtBefore(LocalDateTime createdAtBefore);
+
+    int deleteByIsReadFalseAndCreatedAtBefore(LocalDateTime createdAtBefore);
 }

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -4,10 +4,14 @@ import com.gucci.alarm_service.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
 
     List<Notification> findByReceiverIdAndIsReadFalseOrderByCreatedAtDesc(Long receiverId);
+
+    List<Notification> findByReceiverIdAndIsReadFalse(Long receiverId);
+
 }

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -14,4 +14,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findByReceiverIdAndIsReadFalse(Long receiverId);
 
+    void deleteAllByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/gucci/alarm_service/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/gucci/alarm_service/scheduler/NotificationCleanupScheduler.java
@@ -1,0 +1,35 @@
+package com.gucci.alarm_service.scheduler;
+
+import com.gucci.alarm_service.repository.NotificationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationCleanupScheduler {
+    private final NotificationRepository notificationRepository;
+
+    // 매일 자정에 실행
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void deleteOldNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 읽은 알림 -> 7일 경과 시 삭제
+        LocalDateTime readLimit = now.minusDays(7);
+        int deletedRead = notificationRepository.deleteByIsReadTrueAndCreatedAtBefore(readLimit);
+
+        // 안 읽은 알림 -> 100일 경과 시 삭제
+        LocalDateTime unreadLimit = now.minusDays(100);
+        int deletedUnread = notificationRepository.deleteByIsReadFalseAndCreatedAtBefore(unreadLimit);
+
+        log.info("알림 정리 완료 - 읽은 알림: {}, 안 읽은 알림: {}", deletedRead, deletedUnread);
+    }
+
+}

--- a/src/main/java/com/gucci/alarm_service/service/NotificationWriteService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationWriteService.java
@@ -48,4 +48,10 @@ public class NotificationWriteService {
 
         notifications.forEach(Notification::markAsRead);
     }
+
+    // 전체 알림 삭제
+    @Transactional
+    public void deleteAll(Long receiverId) {
+        notificationRepository.deleteAllByReceiverId(receiverId);
+    }
 }

--- a/src/main/java/com/gucci/alarm_service/service/NotificationWriteService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationWriteService.java
@@ -10,6 +10,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class NotificationWriteService {
@@ -39,4 +41,11 @@ public class NotificationWriteService {
     }
 
 
+    // 전체 읽음 처리
+    @Transactional
+    public void markReadAll(Long receiverId) {
+        List<Notification> notifications = notificationRepository.findByReceiverIdAndIsReadFalse(receiverId);
+
+        notifications.forEach(Notification::markAsRead);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,10 +14,12 @@ spring:
       group-id: alarm-group
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
     producer:
-      key-serializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-serializer: org.apache.kafka.common.serialization.StringDeserializer
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     topic:
       notification: alarm-topic
 

--- a/src/test/java/com/gucci/alarm_service/SchedulerIntegrationTest.java
+++ b/src/test/java/com/gucci/alarm_service/SchedulerIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.gucci.alarm_service;
+
+import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.domain.NotificationType;
+import com.gucci.alarm_service.repository.NotificationRepository;
+import com.gucci.alarm_service.scheduler.NotificationCleanupScheduler;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest
+public class SchedulerIntegrationTest {
+
+    @Autowired
+    private NotificationCleanupScheduler scheduler;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+    }
+
+    @DisplayName("스케줄러가 오래된 알림을 삭제한다")
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void 스케줄러_알림_삭제_테스트() {
+        // given
+        Notification oldRead = Notification.builder()
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.COMMENT)
+                .content("오래된 읽은 알림")
+                .targetUrl("/posts/1")
+                .isRead(true)
+                .createdAt(LocalDateTime.now().minusDays(8))
+                .build();
+
+        Notification oldUnread = Notification.builder()
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.FOLLOW)
+                .content("오래된 안 읽은 알림")
+                .targetUrl("/users/2")
+                .isRead(false)
+                .createdAt(LocalDateTime.now().minusDays(101))
+                .build();
+
+        notificationRepository.save(oldRead);
+        notificationRepository.save(oldUnread);
+
+        // when
+        scheduler.deleteOldNotifications();
+        // then
+        Assertions.assertThat(notificationRepository.findAll()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-63](https://sh0314.atlassian.net/browse/GUC-XX)
- 관련 GitHub 이슈: #9 

---

## ✨ PR Description

- 알림 전체 읽음 처리 추가했습니다.
- 알림 자동 삭제는 매일 정오에 스케쥴러를 이용하여 날짜를 판단하여 삭제하도록 구현했습니다.
  - 읽은 알림은 7일 경과 시, 안 읽은 알림은 100일 경과 시 정오에 삭제됩니다. 
- 알림 전체를 직접 삭제하는 기능도 추가했습니다.

---

## 📝 Requirements for Reviewer

---

## ✅ 체크리스트

- [x] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [x] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [x] 불필요한 주석, 디버깅 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-63]: https://sh0314.atlassian.net/browse/GUC-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ