### PR TITLE
알림 유무 응답 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'com.github.Gachon-Univ-Creative-Code-Innovation:alog-common:v1.0.1'
 	implementation 'org.springframework.kafka:spring-kafka'
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gucci/alarm_service/common/SseEmitterManager.java
+++ b/src/main/java/com/gucci/alarm_service/common/SseEmitterManager.java
@@ -1,6 +1,7 @@
 package com.gucci.alarm_service.common;
 
-import com.gucci.alarm_service.dto.NotificationResponse;
+import com.gucci.alarm_service.dto.NotificationSseEventDTO;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@Slf4j
 public class SseEmitterManager {
 
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
@@ -24,7 +26,7 @@ public class SseEmitterManager {
         return emitter;
     }
 
-    public void send(Long userId, NotificationResponse data) {
+    public void send(Long userId, NotificationSseEventDTO data) {
         SseEmitter emitter = emitters.get(userId);
         if (emitter != null) {
             try {
@@ -33,6 +35,7 @@ public class SseEmitterManager {
                         .data(data));
             } catch (IOException e) {
                 emitters.remove(userId);
+                log.warn("SSE 전송 실패, userId: {}", userId, e);
             }
         }
     }

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -75,4 +75,12 @@ public class NotificationController {
 
         return ApiResponse.success();
     }
+
+    // 읽지 않은 알림 여부
+    @GetMapping("/unread/exists")
+    public ApiResponse<Boolean> unreadAlarmExist(@RequestHeader("X-USER-ID") Long receiverId) {
+        boolean hasUnread = notificationReadService.existUnreadAlarm(receiverId);
+        return ApiResponse.success(hasUnread);
+    }
+
 }

--- a/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
+++ b/src/main/java/com/gucci/alarm_service/controller/NotificationController.java
@@ -21,17 +21,24 @@ public class NotificationController {
     private final NotificationReadService notificationReadService;
     private final NotificationEventHandler notificationEventHandler;
 
-    // 알림 연결(구독)
+    // 알림 연결(구독) / 테스트용 (SSE 로직에 구현함)
     @GetMapping("/subscribe/{userId}")
     public SseEmitter subscribe(@PathVariable Long userId) {
         return notificationEventHandler.subscribe(userId);
     }
 
-    // 알림 전송
+    // 알림 전송 / 테스트용 (SSE 로직에 구현함)
     @PostMapping("/send")
     public ApiResponse<NotificationResponse> alarmCreate(@RequestBody NotificationRequest notificationRequest) {
         NotificationResponse save = notificationWriteService.save(notificationRequest);
         return ApiResponse.success(save);
+    }
+
+    // 읽지 않은 알림 여부 / 테스트용 (SSE 로직에 구현함)
+    @GetMapping("/unread/exists")
+    public ApiResponse<Boolean> unreadAlarmExist(@RequestHeader("X-USER-ID") Long receiverId) {
+        boolean hasUnread = notificationReadService.existUnreadAlarm(receiverId);
+        return ApiResponse.success(hasUnread);
     }
 
     // 전체 알림 조회
@@ -74,13 +81,6 @@ public class NotificationController {
         notificationWriteService.deleteAll(receiverId);
 
         return ApiResponse.success();
-    }
-
-    // 읽지 않은 알림 여부
-    @GetMapping("/unread/exists")
-    public ApiResponse<Boolean> unreadAlarmExist(@RequestHeader("X-USER-ID") Long receiverId) {
-        boolean hasUnread = notificationReadService.existUnreadAlarm(receiverId);
-        return ApiResponse.success(hasUnread);
     }
 
 }

--- a/src/main/java/com/gucci/alarm_service/dto/NotificationKafkaRequest.java
+++ b/src/main/java/com/gucci/alarm_service/dto/NotificationKafkaRequest.java
@@ -3,7 +3,6 @@ package com.gucci.alarm_service.dto;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/gucci/alarm_service/dto/NotificationSseEventDTO.java
+++ b/src/main/java/com/gucci/alarm_service/dto/NotificationSseEventDTO.java
@@ -1,0 +1,19 @@
+package com.gucci.alarm_service.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationSseEventDTO {
+    private NotificationResponse notification;
+    private boolean isExistAlarm;
+
+
+    public static NotificationSseEventDTO from(NotificationResponse notification, boolean isExistAlarm) {
+        return NotificationSseEventDTO.builder()
+                .notification(notification)
+                .isExistAlarm(isExistAlarm)
+                .build();
+    }
+}

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -22,4 +22,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     int deleteByIsReadFalseAndCreatedAtBefore(LocalDateTime createdAtBefore);
 
     boolean existsByReceiverIdAndIsReadFalse(Long receiverId);
+
+    List<Notification> findByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
+++ b/src/main/java/com/gucci/alarm_service/repository/NotificationRepository.java
@@ -20,4 +20,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     int deleteByIsReadTrueAndCreatedAtBefore(LocalDateTime createdAtBefore);
 
     int deleteByIsReadFalseAndCreatedAtBefore(LocalDateTime createdAtBefore);
+
+    boolean existsByReceiverIdAndIsReadFalse(Long receiverId);
 }

--- a/src/main/java/com/gucci/alarm_service/service/NotificationReadService.java
+++ b/src/main/java/com/gucci/alarm_service/service/NotificationReadService.java
@@ -29,4 +29,8 @@ public class NotificationReadService {
                 .collect(Collectors.toList());
     }
 
+    // 안 읽은 메시지 여부
+    public boolean existUnreadAlarm(Long receiverId) {
+        return notificationRepository.existsByReceiverIdAndIsReadFalse(receiverId);
+    }
 }

--- a/src/test/java/com/gucci/alarm_service/SchedulerIntegrationTest.java
+++ b/src/test/java/com/gucci/alarm_service/SchedulerIntegrationTest.java
@@ -10,12 +10,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public class SchedulerIntegrationTest {
 
     @Autowired
@@ -31,7 +33,7 @@ public class SchedulerIntegrationTest {
 
     @DisplayName("스케줄러가 오래된 알림을 삭제한다")
     @Test
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Transactional
     void 스케줄러_알림_삭제_테스트() {
         // given
         Notification oldRead = Notification.builder()

--- a/src/test/java/com/gucci/alarm_service/controller/NotificationControllerTest.java
+++ b/src/test/java/com/gucci/alarm_service/controller/NotificationControllerTest.java
@@ -3,6 +3,7 @@ package com.gucci.alarm_service.controller;
 
 import com.gucci.alarm_service.domain.NotificationType;
 import com.gucci.alarm_service.dto.NotificationResponse;
+import com.gucci.alarm_service.service.NotificationEventHandler;
 import com.gucci.alarm_service.service.NotificationReadService;
 import com.gucci.alarm_service.service.NotificationWriteService;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -24,9 +26,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("알림 읽음 처리 테스트")
 @WebMvcTest(NotificationController.class)
+@ActiveProfiles("test")
 public class NotificationControllerTest {
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationEventHandler notificationEventHandler;
 
     @MockBean
     private NotificationWriteService notificationWriteService;

--- a/src/test/java/com/gucci/alarm_service/controller/NotificationSendApiTest.java
+++ b/src/test/java/com/gucci/alarm_service/controller/NotificationSendApiTest.java
@@ -1,0 +1,78 @@
+package com.gucci.alarm_service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gucci.alarm_service.domain.Notification;
+import com.gucci.alarm_service.domain.NotificationType;
+import com.gucci.alarm_service.dto.NotificationRequest;
+import com.gucci.alarm_service.dto.NotificationResponse;
+import com.gucci.alarm_service.repository.NotificationRepository;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+public class NotificationSendApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @DisplayName("성공적으로 알림을 저장하고 응답을 반환한다.")
+    @Test
+    void 알림_전송_저장_성공() throws Exception {
+        // given
+        NotificationRequest request = NotificationRequest.builder()
+                .receiverId(1L)
+                .senderId(2L)
+                .type(NotificationType.COMMENT)
+                .content("테스트 댓글 알림")
+                .targetUrl("/posts/1")
+                .referenceId(123L)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/alarm-service/notifications/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").value("테스트 댓글 알림"))
+                .andExpect(jsonPath("$.data.receiverId").value(1L));
+
+        // DB 저장까지 확인
+        List<Notification> notifications = notificationRepository.findByReceiverId(1L);
+        Assertions.assertThat(notifications).isNotEmpty();
+        Assertions.assertThat(notifications.get(0).getContent()).isEqualTo("테스트 댓글 알림");
+
+
+    }
+
+    private static String asJsonString(final Object obj) {
+        try {
+            return new ObjectMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+
+}

--- a/src/test/java/com/gucci/alarm_service/controller/NotificationSubscribeTest.java
+++ b/src/test/java/com/gucci/alarm_service/controller/NotificationSubscribeTest.java
@@ -1,0 +1,32 @@
+package com.gucci.alarm_service.controller;
+
+import com.gucci.alarm_service.service.NotificationEventHandler;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class NotificationSubscribeTest {
+
+    @Autowired
+    private NotificationEventHandler notificationEventHandler;
+
+    @DisplayName("SSE 구독 요청 시 emitter가 정상적으로 생성된다.")
+    @Test
+    void SSE_구독_테스트() {
+        // given
+        Long userId = 1L;
+
+        // when
+        SseEmitter emitter = notificationEventHandler.subscribe(userId);
+
+        // then
+        Assertions.assertThat(emitter).isNotNull();
+
+    }
+}

--- a/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
+++ b/src/test/java/com/gucci/alarm_service/service/NotificationServiceTest.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class NotificationServiceTest {
@@ -54,15 +56,15 @@ public class NotificationServiceTest {
                 .build();
 
 
-        Mockito.when(notificationRepository.save(Mockito.any(Notification.class))).thenReturn(expected);
+        when(notificationRepository.save(Mockito.any(Notification.class))).thenReturn(expected);
 
         //when
         NotificationResponse saved = notificationWriteService.save(request);
 
         //then
-        assertThat(saved.getReceiverId()).isEqualTo(1L);
-        assertThat(saved.getType()).isEqualTo(NotificationType.COMMENT);
-        assertThat(saved.getContent()).isEqualTo("댓글이 달렸습니다.");
+        assertThat(saved.getReceiverId()).isEqualTo(expected.getReceiverId());
+        assertThat(saved.getType()).isEqualTo(expected.getType());
+        assertThat(saved.getContent()).isEqualTo(expected.getContent());
     }
 
     @DisplayName("안 읽은 알림만 필터링해서 반환")
@@ -126,5 +128,35 @@ public class NotificationServiceTest {
         assertThat(notification.isRead()).isTrue();
         then(notificationRepository).should().findById(notificationId);
 
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림이 존재할 때 true를 반환한다")
+    void 읽지_않은_알림_존재_true_반환(){
+        // given
+        Long userId = 1L;
+        when(notificationRepository.existsByReceiverIdAndIsReadFalse(userId)).thenReturn(true);
+
+        //when
+        boolean result = notificationReadService.existUnreadAlarm(userId);
+
+        //then
+        assertThat(result).isTrue();
+        verify(notificationRepository).existsByReceiverIdAndIsReadFalse(userId);
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림이 존재하지 않을 때 false를 반환한다")
+    void 읽지_않은_알림_존재하지_않으면_false_반환(){
+        // given
+        Long userId = 1L;
+        when(notificationRepository.existsByReceiverIdAndIsReadFalse(userId)).thenReturn(false);
+
+        //when
+        boolean result = notificationReadService.existUnreadAlarm(userId);
+
+        //then
+        assertThat(result).isFalse();
+        verify(notificationRepository).existsByReceiverIdAndIsReadFalse(userId);
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  kafka:
+    bootstrap-servers: dummy:9092 # 테스트에서는 실제 브로커 사용 안 함
+    consumer:
+      group-id: test-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    topic:
+      notification: test-alarm-topic
+
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-36](https://sh0314.atlassian.net/browse/GUC-36)
- 관련 GitHub 이슈: #11 

---

## ✨ PR Description
- 알림 유무 표시를 위한 응답값을 추가로 제공하도록 기능을 추가했습니다.


---

## 📝 Requirements for Reviewer
---

## ✅ 체크리스트

- [x] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [x] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [ ] 불필요한 주석, 디버깅 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-36]: https://sh0314.atlassian.net/browse/GUC-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ